### PR TITLE
Fix get_repo_info() function to handle trailing slash in repository URLs

### DIFF
--- a/server/embeddings.py
+++ b/server/embeddings.py
@@ -157,10 +157,13 @@ def compute_prefix_and_zip_url(repo_url, main_branch="main"):
 def get_repo_info(url):
     # Parse the URL and split the path
     parsed_url = urlparse(url)
-    path_parts = parsed_url.path.split("/")
+    path_parts = parsed_url.path.strip("/").split("/")
 
     # The repo name is the last part of the path
-    repo_name = path_parts[-1]
+    if path_parts[-1] == "":
+        repo_name = path_parts[-2]
+    else:
+        repo_name = path_parts[-1]
 
     # The owner is the second-to-last part of the path
     owner = path_parts[-2]


### PR DESCRIPTION
PR Body:

## Issue
The current implementation of the `get_repo_info()` function in our application is not robust enough to handle different formats of the repository URLs. This function is supposed to parse a GitHub repository URL and return the repository owner and repository name. However, if the URL ends with a trailing slash, the function doesn't work as expected.

## Proposed Solution
I have made the necessary changes to the `get_repo_info()` function to ensure that it correctly handles URLs with trailing slashes. The updated code now properly parses the URL and splits the path, considering the trailing slash as part of the path.

## How to Reproduce
To reproduce the issue, call the `get_repo_info()` function with a GitHub repository URL that ends with a trailing slash, such as "https://github.com/aayushmathur7/raja-app/". Notice that the function does not return the correct owner and repository name. Instead, it considers the trailing slash as the last part of the path, leading to incorrect results. 

Call the function with a URL that doesn't end with a trailing slash, such as "https://github.com/aayushmathur7/raja-app". Notice that the function works as expected in this case.

## Acceptance Criteria
- The `get_repo_info()` function should correctly parse GitHub repository URLs regardless of whether they end with a trailing slash or not.
- The function should return the correct owner and repository name for the input URL.
- The function should include proper error handling to deal with invalid or incorrectly formatted URLs.