### PR TITLE
Implement task_failed status type in checkrajataskstatus function

### DIFF
--- a/src/components/dashboard/TaskTable.jsx
+++ b/src/components/dashboard/TaskTable.jsx
@@ -17,6 +17,8 @@ export default function TaskTable() {
             return "In progress";
         } else if (status === StatusType.PR_READY_FOR_REVIEW) {
             return "PR ready for review";
+        } else if (status === StatusType.TASK_FAILED) {
+            return "Task failed";
         }
     }
 
@@ -27,6 +29,8 @@ export default function TaskTable() {
             return "bg-yellow-50 text-yellow-700 ring-yellow-600";
         } else if (status === StatusType.PR_READY_FOR_REVIEW) {
             return "bg-green-50 text-green-700 ring-green-600";
+        } else if (status === StatusType.TASK_FAILED) {
+            return "bg-red-50 text-red-700 ring-red-600";
         }
     }
 
@@ -101,6 +105,14 @@ export default function TaskTable() {
                       : task
                   );
                   updateTasks(updatedTasks);
+                } else if (data.status === 'FAILURE') {
+                  clearInterval(intervalId); // stop polling when the task is done
+                  updatedTasks = updatedTasks.map(task =>
+                    task.name === taskToUpdate.name
+                      ? { ...task, status: StatusType.TASK_FAILED }
+                      : task
+                  );
+                  updateTasks(updatedTasks);
                 }
               })
               .catch(err => {
@@ -111,10 +123,6 @@ export default function TaskTable() {
         })
         .catch(err => console.error(err));
     };
-
-
-
-
 
   return (
     <div className="px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
PR Body:

**Description:**

This PR introduces a new status type, `task_failed`, to improve the robustness of our status tracking system and provide more detailed monitoring. The implementation involves updating the `statustype` enum, adding a unique color for the `task_failed` status, and modifying the `checkrajataskstatus` method to handle the new status type.

**Changes Made:**

1. Updated the `statustype` enum to include a new value, `task_failed`, representing a failed task status.
2. Added a unique color, `bg-red-50 text-red-700 ring-red-600`, for the `task_failed` status to enhance visual recognition.
3. Modified the `checkrajataskstatus` method to include a conditional check for `data.status` to identify if it equals "failure". If `data.status` returns "failure", the status is changed to `task_failed` and the fetch request is left unchanged.

**Testing:**

To test the implementation, follow these steps:

1. Set up a debug environment for the application with access to a test version of the `checkrajataskstatus` function.
2. Trigger a "failure" status by manipulating the response such that `data.status == "failure"` while calling the `checkrajataskstatus` function.
3. Validate that the new status type, `task_failed`, is set correctly after the "failure" status is triggered.
4. Check if the statusclass color `bg-red-50 text-red-700 ring-red-600` is displayed when the `task_failed` status is set.

**Acceptance Criteria:**

This feature implementation can be considered successful if:

1. The `checkrajataskstatus` method accurately changes the status to `task_failed` when `data.status` is equal to "failure".
2. The `task_failed` status is represented with the statusclass color `bg-red-50 text-red-700 ring-red-600`.

Please review and merge this PR once the above criteria are met.