### PR TITLE
Implement task_failed status type in checkrajataskstatus function

### DIFF
--- a/src/components/dashboard/TaskTable.jsx
+++ b/src/components/dashboard/TaskTable.jsx
@@ -17,6 +17,8 @@ export default function TaskTable() {
             return "In progress";
         } else if (status === StatusType.PR_READY_FOR_REVIEW) {
             return "PR ready for review";
+        } else if (status === StatusType.TASK_FAILED) {
+            return "Task failed";
         }
     }
 
@@ -27,6 +29,8 @@ export default function TaskTable() {
             return "bg-yellow-50 text-yellow-700 ring-yellow-600";
         } else if (status === StatusType.PR_READY_FOR_REVIEW) {
             return "bg-green-50 text-green-700 ring-green-600";
+        } else if (status === StatusType.TASK_FAILED) {
+            return "bg-red-50 text-red-700 ring-red-600";
         }
     }
 
@@ -101,6 +105,14 @@ export default function TaskTable() {
                       : task
                   );
                   updateTasks(updatedTasks);
+                } else if (data.status === 'FAILURE') {
+                  clearInterval(intervalId); // stop polling when the task fails
+                  updatedTasks = updatedTasks.map(task =>
+                    task.name === taskToUpdate.name
+                      ? { ...task, status: StatusType.TASK_FAILED }
+                      : task
+                  );
+                  updateTasks(updatedTasks);
                 }
               })
               .catch(err => {
@@ -111,10 +123,6 @@ export default function TaskTable() {
         })
         .catch(err => console.error(err));
     };
-
-
-
-
 
   return (
     <div className="px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
PR Body:

**Implement task_failed status type on failure in checkrajataskstatus**

**Description:**
To improve the robustness of our status tracking system and ensure more detailed monitoring, we need to introduce a new status type: task_failed. This will specifically be utilized to indicate failure states in the checkrajataskstatus function.

**Implementation Steps:**

1. Update statustype enum: The statustype enum currently in use needs to be updated to incorporate a new value, task_failed. This will represent a failed task status.

2. Add statusclass color: For better visual recognition of the failed status, a unique color will be associated with it. The assigned statusclass color for task_failed should be bg-red-50 text-red-700 ring-red-600.

3. Modify checkrajataskstatus method: Update the checkrajataskstatus method. This involves adding a conditional check for data.status to identify if it equals "failure". In cases where data.status returns "failure", the status should be changed to task_failed and the fetch request is left.

**How to Reproduce:**
This feature is a new addition to the codebase, so there is currently no way to reproduce the issue that this feature aims to address. However, we can test the status update by artificially causing a "failure" status. Here's how we might go about it:

1. Setup a debug environment: Setup a debug environment for the application with access to a test version of the checkrajataskstatus function.

2. Trigger a "failure" status: While calling the checkrajataskstatus function, manipulate the response such that data.status == "failure".

3. Validate task_failed status: After the "failure" status is triggered, check if the new status type task_failed is set correctly.

4. Check statusclass color: When task_failed status is set, validate if the statusclass color bg-red-50 text-red-700 ring-red-600 is displayed.

**Acceptance Criteria:**
We can confirm the successful implementation of this feature when:

1. The checkrajataskstatus method accurately changes the status to task_failed when data.status is equal to "failure".
2. The status associated with task_failed is represented with the statusclass color bg-red-50 text-red-700 ring-red-600.